### PR TITLE
Feat/#9 add shared api config

### DIFF
--- a/src/app/_providers/SocketProvider.tsx
+++ b/src/app/_providers/SocketProvider.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { socketContext } from '@/shared/api/socket';
+import { ReactNode, useEffect, useState } from 'react';
+import { Socket } from 'socket.io-client';
+
+export const SocketProvider = ({ children }: { children: ReactNode }) => {
+  const [socket, setSocket] = useState(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    const socket = new (Socket as any)(process.env.NEXT_PUBLIC_SOCKET_URL!, {});
+
+    socket.on('connect_error', (error: any) => {
+      console.error('Socket connection error:', error);
+      setIsConnected(false);
+    });
+
+    socket.on('connect', () => {
+      setIsConnected(true);
+    });
+
+    socket.on('disconnect', () => {
+      setIsConnected(false);
+    });
+
+    setSocket(socket);
+
+    return () => {
+      socket.disconnect();
+    };
+  }, []);
+
+  return (
+    <socketContext.Provider value={{ socket, isConnected }}>{children}</socketContext.Provider>
+  );
+};

--- a/src/app/_providers/index.ts
+++ b/src/app/_providers/index.ts
@@ -1,0 +1,1 @@
+export { SocketProvider } from './SocketProvider';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { SocketProvider } from "@/app/_providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,11 +24,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+    <html lang='en'>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <SocketProvider>{children}</SocketProvider>
       </body>
     </html>
   );

--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -1,0 +1,63 @@
+import axios, { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+interface ExtendedAxiosRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
+const api: AxiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+api.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('accessToken');
+      if (token) {
+        config.headers.set('Authorization', `Bearer ${token}`);
+      }
+    }
+    return config;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error);
+  },
+);
+
+api.interceptors.response.use(
+  (response: AxiosResponse) => {
+    return response;
+  },
+  async (error: AxiosError) => {
+    const originalRequest = error.config as ExtendedAxiosRequestConfig | undefined;
+    if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        if (typeof window !== 'undefined') {
+          const refreshToken = localStorage.getItem('refreshToken');
+          if (refreshToken) {
+            const response = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`, {
+              refreshToken,
+            });
+            const { accessToken } = response.data;
+            localStorage.setItem('accessToken', accessToken);
+            originalRequest.headers.set('Authorization', `Bearer ${accessToken}`);
+            return api(originalRequest);
+          }
+        }
+      } catch (refreshError) {
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          window.location.href = '/login';
+        }
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default api;

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,1 +1,0 @@
-// remove this file

--- a/src/shared/api/socket.ts
+++ b/src/shared/api/socket.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+type contextType = {
+  socket: any | null;
+  isConnected: boolean;
+};
+
+export const socketContext = createContext<contextType>({
+  socket: null,
+  isConnected: false,
+});
+
+export const useSocket = () => {
+  return useContext(socketContext);
+};


### PR DESCRIPTION
## Shared 레이어 API 파일 추가
#### axios instance
- axios instance 를 구성하였습니다.
- interceptor 기능을 포함하고 있습니다.
- request 는 `accessToken` 을 header 에 포함합니다. 
- response 는 401 오류 발생시 refresh 갱신 로직을 포함하고 있습니다.
- refresh 갱신 실패 시 로그아웃 처리, 리디렉션을 진행합니다.
#### socket context
- socket 연결을 위한 컨텍스트를 구성하였습니다.
- fsd 원칙에 따라 최상위 레이어 app 에서 정의될 provider 에 대해 비즈니스 로직 정의을 최소화하였습니다.
#### socket provider
- 서비스 전역 구성을 위한 socket provider 를 구성하였습니다.
- fsd 원칙에 따른 socket context 정의에 따라 비즈니스 로직이 제외된 소켓 연결, 해제만을 처리합니다.

> 추후 entities, features 레이어에서 socket 도메인 비즈니스 로직을 별도로 구성