### PR TITLE
Feat/#45 chatroom list page 2

### DIFF
--- a/src/app/(main)/chats/page.tsx
+++ b/src/app/(main)/chats/page.tsx
@@ -1,5 +1,12 @@
+'use client';
+
 import { ChatRoomListPage } from '@/views/chat';
+import { Suspense } from 'react';
 
 export default function ChatsPage() {
-  return <ChatRoomListPage />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ChatRoomListPage />
+    </Suspense>
+  );
 }

--- a/src/entities/chat/model/types.ts
+++ b/src/entities/chat/model/types.ts
@@ -7,6 +7,4 @@ export interface ChatRoom {
   isRead: boolean; // 마지막 메시지 읽음 여부
 }
 
-export interface ChatRoomList {
-  chatRooms: ChatRoom[]; // 채팅방 목록을 배열로 변경
-}
+export type ChatRoomList = ChatRoom[];

--- a/src/entities/chat/ui/ChatRoomItem.tsx
+++ b/src/entities/chat/ui/ChatRoomItem.tsx
@@ -12,21 +12,26 @@ interface ChatRoomItemProps {
 export const ChatRoomItem = (props: ChatRoomItemProps) => {
   const { chatRoom } = props;
   return (
-    <Link href={`/chats/${chatRoom.chatRoomId}`} className={clsx(props.className)}>
-      <div className="flex h-20 items-center justify-between gap-3 px-4 py-3">
-        <div className="flex min-w-0 flex-grow items-center gap-3">
-          <Avatar className="h-14 w-14 flex-shrink-0">
-            <AvatarImage src={chatRoom.imageUrl} alt={chatRoom.name} />
-            <AvatarFallback className="bg-gray-300">{chatRoom.name.charAt(0)}</AvatarFallback>
-          </Avatar>
-          <div className="flex min-w-0 flex-1 flex-col">
-            <p className="mb-1 truncate text-base font-medium">{chatRoom.name}</p>
-            <div className="truncate text-sm text-gray-500">{chatRoom.lastContent}</div>
-          </div>
+    <Link href={`/chats/${chatRoom.chatRoomId}`} className="flex h-20 gap-3 px-4 py-3">
+      <Avatar className="h-14 w-14">
+        <AvatarImage src={chatRoom.imageUrl} alt={chatRoom.name} />
+        <AvatarFallback className="bg-gray-300">{chatRoom.name.charAt(0)}</AvatarFallback>
+      </Avatar>
+
+      <div className="flex flex-grow flex-col justify-center">
+        <div className="mb-1 flex items-center justify-between gap-3">
+          <p className="line-clamp-1 overflow-hidden text-base font-medium text-ellipsis">{chatRoom.name}</p>
+          <p className="flex-shrink-0 text-sm text-gray-500">{formatChatTime(chatRoom.lastSendAt)}</p>
         </div>
-        <div className="flex h-full flex-shrink-0 flex-col items-end justify-center">
-          <div className="mb-1 text-sm text-gray-500">{formatChatTime(chatRoom.lastSendAt)}</div>
-          <div className={clsx('h-4 w-4 rounded-full', chatRoom.isRead ? 'bg-transparent' : 'bg-blue-500')}></div>
+
+        <div className="flex items-center justify-between gap-3">
+          <p className="line-clamp-2 overflow-hidden text-sm text-ellipsis text-gray-500">{chatRoom.lastContent}</p>
+          <div
+            className={clsx(
+              'h-2 w-2 flex-shrink-0 rounded-full bg-blue-500',
+              chatRoom.isRead ? 'bg-transparent' : 'bg-blue-500',
+            )}
+          ></div>
         </div>
       </div>
     </Link>

--- a/src/entities/message/model/slice.ts
+++ b/src/entities/message/model/slice.ts
@@ -2,18 +2,18 @@ import { create } from 'zustand';
 import { MessageRes, MessageList } from './types';
 
 interface MessageState {
-  messages: MessageList; // 채팅방별 메시지 목록
-  currentRoomMessages: MessageRes[]; // 현재 채팅방의 메시지들
-  currentRoomId: number | null; // 현재 채팅방 ID 추가
+  messages: Record<number, MessageList>; // 채팅방별 메시지 목록 (roomId -> MessageRes[])
+  currentRoomMessages: MessageList; // 현재 채팅방의 메시지들
+  currentRoomId: number | null; // 현재 채팅방 ID
   isLoading: boolean; // 메시지 로딩 상태
   isLoadingMore: boolean; // 더 많은 메시지 로딩 상태
   hasMore: boolean; // 더 많은 메시지가 있는지 여부
   lastMessageId: string | null; // 마지막 메시지 ID
 
-  setMessages: (roomId: number, messages: MessageRes[]) => void; // 채팅방별 메시지 목록 설정
+  setMessages: (roomId: number, messages: MessageList) => void; // 채팅방별 메시지 목록 설정
   addMessage: (roomId: number, message: MessageRes) => void; // 단일 메시지 추가
-  addMessages: (roomId: number, messages: MessageRes[]) => void; // 메시지들 추가
-  prependMessages: (roomId: number, messages: MessageRes[]) => void; // 메시지들 앞에 추가
+  addMessages: (roomId: number, messages: MessageList) => void; // 메시지들 추가
+  prependMessages: (roomId: number, messages: MessageList) => void; // 메시지들 앞에 추가
   setCurrentRoomMessages: (roomId: number) => void; // 현재 채팅방 메시지 설정
   setLoading: (loading: boolean) => void; // 로딩 상태 설정
   setLoadingMore: (loading: boolean) => void; // 추가 로딩 상태 설정
@@ -26,14 +26,14 @@ interface MessageState {
 export const useMessageStore = create<MessageState>((set) => ({
   messages: {},
   currentRoomMessages: [],
-  currentRoomId: null, // 현재 채팅방 ID 추가
+  currentRoomId: null,
   isLoading: false,
   isLoadingMore: false,
   hasMore: true,
   lastMessageId: null,
 
   // 메시지 설정
-  setMessages: (roomId: number, messages: MessageRes[]) => {
+  setMessages: (roomId: number, messages: MessageList) => {
     set((state) => ({
       messages: {
         ...state.messages,
@@ -60,7 +60,7 @@ export const useMessageStore = create<MessageState>((set) => ({
   },
 
   // 메시지들 추가 (초기 로드 시)
-  addMessages: (roomId: number, messages: MessageRes[]) => {
+  addMessages: (roomId: number, messages: MessageList) => {
     set((state) => {
       const existingMessages = state.messages[roomId] || [];
       const updatedMessages = [...existingMessages, ...messages];
@@ -74,7 +74,7 @@ export const useMessageStore = create<MessageState>((set) => ({
   },
 
   // 메시지들 앞에 추가 (이전 메시지 로드 시)
-  prependMessages: (roomId: number, messages: MessageRes[]) => {
+  prependMessages: (roomId: number, messages: MessageList) => {
     set((state) => {
       const existingMessages = state.messages[roomId] || [];
       const updatedMessages = [...messages, ...existingMessages];

--- a/src/entities/message/model/types.ts
+++ b/src/entities/message/model/types.ts
@@ -19,6 +19,4 @@ export interface MessageAck {
   userId: number;
 }
 
-export interface MessageList {
-  [roomId: number]: MessageRes[];
-}
+export type MessageList = MessageRes[];

--- a/src/features/update-message/model/loadMessage.ts
+++ b/src/features/update-message/model/loadMessage.ts
@@ -33,8 +33,8 @@ export const useLoadMessage = (roomId: number, pageSize: number = 30) => {
       console.log(`채팅방 ${roomId} 초기 메시지 로드 시작`);
       const messageList = await getMessageList(roomId);
 
-      if (messageList && messageList[roomId]) {
-        const roomMessages = messageList[roomId];
+      if (messageList && Array.isArray(messageList)) {
+        const roomMessages = messageList;
         setMessages(roomId, roomMessages);
         setCurrentRoomMessages(roomId);
 
@@ -73,8 +73,8 @@ export const useLoadMessage = (roomId: number, pageSize: number = 30) => {
       console.log(`채팅방 ${roomId} 추가 메시지 로드 시작 (lastId: ${lastMessageId})`);
       const messageList = await getMoreMessageList(roomId, parseInt(lastMessageId));
 
-      if (messageList && messageList[roomId]) {
-        const newMessages = messageList[roomId];
+      if (messageList && Array.isArray(messageList)) {
+        const newMessages = messageList;
 
         if (newMessages.length > 0) {
           // 새 메시지들을 기존 메시지 앞에 추가

--- a/src/views/chat/ui/ChatRoomListPage.tsx
+++ b/src/views/chat/ui/ChatRoomListPage.tsx
@@ -6,7 +6,6 @@ export const ChatRoomListPage = () => {
     <>
       <ChatRoomListHeader />
       <ChatRoomList />
-      {/* 네비게이션 */}
     </>
   );
 };

--- a/src/widgets/chat/ui/ChatRoomList.tsx
+++ b/src/widgets/chat/ui/ChatRoomList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { ChatRoom } from '@/entities/chat';
 import { ChatRoomItem } from '@/entities/chat';
 import { getChatRoomList } from '@/entities/chat/api/getChatRoomList';
+import { ScrollArea } from '@/shared/ui/ScrollArea';
 
 export const ChatRoomList = () => {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([]);
@@ -51,10 +52,10 @@ export const ChatRoomList = () => {
   }
 
   return (
-    <div className="h-full">
+    <ScrollArea className="h-[calc(100vh-54px)] pb-[56px]">
       {chatRooms.map((chatRoom) => (
         <ChatRoomItem key={chatRoom.chatRoomId} chatRoom={chatRoom} />
       ))}
-    </div>
+    </ScrollArea>
   );
 };

--- a/src/widgets/chat/ui/ChatRoomList.tsx
+++ b/src/widgets/chat/ui/ChatRoomList.tsx
@@ -15,9 +15,9 @@ export const ChatRoomList = () => {
       try {
         setIsLoading(true);
         const data = await getChatRoomList();
-        setChatRooms(data.chatRooms);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : '채팅방 목록을 불러오는데 실패했습니다.');
+        setChatRooms(data);
+      } catch (error) {
+        setError(error instanceof Error ? error.message : '채팅방 목록을 불러오는데 실패했습니다.');
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
# 채팅방 리스트 페이지 2차 작업
- 프로덕션에서 발생하던 백엔드 타입 불일치로 인한 클라이언트 에러를 추론적으로 해결했습니다.
- 채팅방 페이지에서 사용되는 widgets 레이어 속 리스트 컴포넌트를 shadcn ScrollArea 컴포넌트로 출력되도록 수정했습니다.
- 채팅방 아이템 컴포넌트의 레이아웃이 불규칙한 문제를 해결했습니다.