### PR TITLE
Feat/#55 chatroom feature advenced

### DIFF
--- a/src/app/_providers/StompProvider.tsx
+++ b/src/app/_providers/StompProvider.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { stompContext } from '@/shared/api/stomp';
+import { tokenEventBus } from '@/shared/lib/tokenEventBus';
 import { Client, IFrame } from '@stomp/stompjs';
 import { useRouter } from 'next/navigation';
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState, useCallback } from 'react';
 import SockJS from 'sockjs-client';
 
 export const StompProvider = ({ children }: { children: ReactNode }) => {
@@ -12,58 +13,99 @@ export const StompProvider = ({ children }: { children: ReactNode }) => {
   const reconnectAttempts = useRef(0);
   const maxReconnectAttempts = 5;
   const router = useRouter();
+  const currentTokenRef = useRef<string | null>(null);
 
+  // STOMP 클라이언트 생성 함수
+  const createStompClient = useCallback(
+    (token: string) => {
+      const stompClient = new Client({
+        webSocketFactory: () => new SockJS(process.env.NEXT_PUBLIC_STOMP_URL!),
+        connectHeaders: {
+          Authorization: `Bearer ${token}`,
+        },
+        reconnectDelay: 5000,
+        heartbeatIncoming: 4000,
+        heartbeatOutgoing: 4000,
+      });
+
+      stompClient.onConnect = () => {
+        console.log('STOMP 연결 성공');
+        setIsConnected(true);
+        reconnectAttempts.current = 0;
+      };
+
+      stompClient.onDisconnect = () => {
+        console.log('STOMP 연결 끊김');
+        setIsConnected(false);
+      };
+
+      stompClient.onStompError = (frame: IFrame) => {
+        console.error('STOMP 오류:', frame);
+        setIsConnected(false);
+
+        if (reconnectAttempts.current < maxReconnectAttempts) {
+          reconnectAttempts.current++;
+          console.log(`STOMP 재연결 시도 ${reconnectAttempts.current}/${maxReconnectAttempts}`);
+        } else {
+          console.log('STOMP 최대 재연결 시도 횟수 초과');
+        }
+      };
+
+      return stompClient;
+    },
+    [maxReconnectAttempts],
+  );
+
+  // 토큰 변경 시 재연결
+  const reconnectWithNewToken = useCallback(
+    (newToken: string) => {
+      // 같은 토큰이면 재연결하지 않음
+      if (currentTokenRef.current === newToken) {
+        return;
+      }
+
+      console.log('새로운 토큰으로 STOMP 재연결 시도');
+
+      // 기존 클라이언트가 있으면 비활성화
+      if (client) {
+        client.deactivate();
+      }
+
+      // 새로운 클라이언트 생성 및 연결
+      const newStompClient = createStompClient(newToken);
+      newStompClient.activate();
+      setClient(newStompClient);
+      currentTokenRef.current = newToken;
+    },
+    [client, createStompClient],
+  );
+
+  // 초기 연결
   useEffect(() => {
     const token = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
 
     if (!token) {
-      console.log('stomp 연결 실패: 토큰이 없습니다.');
+      console.log('STOMP 연결 실패: 토큰이 없습니다.');
       router.push('/');
       return;
     }
 
-    const stompClient = new Client({
-      webSocketFactory: () => new SockJS(process.env.NEXT_PUBLIC_STOMP_URL!),
-      connectHeaders: {
-        Authorization: `Bearer ${token}`,
-      },
-      // 재연결 설정
-      reconnectDelay: 5000, // 재연결 딜레이
-      heartbeatIncoming: 4000, // 하트비트 수신 주기
-      heartbeatOutgoing: 4000, // 하트비트 전송 주기
-    });
-
-    stompClient.onConnect = () => {
-      console.log('stomp 연결 성공');
-      setIsConnected(true);
-      reconnectAttempts.current = 0;
-    };
-
-    stompClient.onDisconnect = () => {
-      console.log('stomp 연결 끊김');
-      setIsConnected(false);
-    };
-
-    stompClient.onStompError = (frame: IFrame) => {
-      console.error('stomp 오류:', frame);
-      setIsConnected(false);
-
-      if (reconnectAttempts.current < maxReconnectAttempts) {
-        reconnectAttempts.current++;
-        console.log(`stomp 재연결 시도 ${reconnectAttempts.current}/${maxReconnectAttempts}`);
-      } else {
-        console.log('stomp 최대 재연결 시도 횟수 초과');
-      }
-    };
-
+    currentTokenRef.current = token;
+    const stompClient = createStompClient(token);
     stompClient.activate();
     setClient(stompClient);
 
     return () => {
-      console.log('stomp 연결 끊김');
+      console.log('STOMP 연결 끊김');
       stompClient.deactivate();
     };
-  }, [router]);
+  }, [router, createStompClient]);
+
+  // 토큰 변경 감지 (의존성 배열에서 client 제거)
+  useEffect(() => {
+    const unsubscribe = tokenEventBus.subscribe(reconnectWithNewToken);
+    return unsubscribe;
+  }, [reconnectWithNewToken]);
 
   return <stompContext.Provider value={{ client, isConnected }}>{children}</stompContext.Provider>;
 };

--- a/src/entities/message/index.ts
+++ b/src/entities/message/index.ts
@@ -2,6 +2,3 @@ export { getMessageList } from './api/getMessageList';
 export { getMoreMessageList } from './api/getMoreMessageList';
 export { useMessageStore } from './model/slice';
 export type { MessageReq, MessageRes, MessageAck, MessageList } from './model/types';
-export { MessageBubble } from './ui/MessageBubble';
-export { groupMessages } from './lib/messageGrouping';
-export type { GroupedMessage } from './lib/messageGrouping';

--- a/src/entities/message/model/slice.ts
+++ b/src/entities/message/model/slice.ts
@@ -2,25 +2,23 @@ import { create } from 'zustand';
 import { MessageRes, MessageList } from './types';
 
 interface MessageState {
-  messages: Record<number, MessageList>; // 채팅방별 메시지 목록 (roomId -> MessageRes[])
-  currentRoomMessages: MessageList; // 현재 채팅방의 메시지들
-  currentRoomId: number | null; // 현재 채팅방 ID
-  isLoading: boolean; // 메시지 로딩 상태
-  isLoadingMore: boolean; // 더 많은 메시지 로딩 상태
-  hasMore: boolean; // 더 많은 메시지가 있는지 여부
-  lastMessageId: string | null; // 마지막 메시지 ID
-
-  setMessages: (roomId: number, messages: MessageList) => void; // 채팅방별 메시지 목록 설정
-  addMessage: (roomId: number, message: MessageRes) => void; // 단일 메시지 추가
-  addMessages: (roomId: number, messages: MessageList) => void; // 메시지들 추가
-  prependMessages: (roomId: number, messages: MessageList) => void; // 메시지들 앞에 추가
-  setCurrentRoomMessages: (roomId: number) => void; // 현재 채팅방 메시지 설정
-  setLoading: (loading: boolean) => void; // 로딩 상태 설정
-  setLoadingMore: (loading: boolean) => void; // 추가 로딩 상태 설정
-  setHasMore: (hasMore: boolean) => void; // 더 불러올 메시지가 있는지 설정
-  setLastMessageId: (messageId: string | null) => void; // 마지막 메시지 ID 설정
-  clearMessages: (roomId?: number) => void; // 특정 채팅방 메시지 초기화
-  clearAllMessages: () => void; // 모든 메시지 초기화
+  messages: Record<number, MessageList>;
+  currentRoomMessages: MessageList;
+  currentRoomId: number | null;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  lastMessageId: string | null;
+  setMessages: (roomId: number, messages: MessageList) => void;
+  addMessage: (roomId: number, message: MessageRes) => void;
+  prependMessages: (roomId: number, messages: MessageList) => void;
+  setCurrentRoomMessages: (roomId: number) => void;
+  setLoading: (loading: boolean) => void;
+  setLoadingMore: (loading: boolean) => void;
+  setHasMore: (hasMore: boolean) => void;
+  setLastMessageId: (messageId: string | null) => void;
+  clearMessages: (roomId?: number) => void;
+  clearAllMessages: () => void;
 }
 
 export const useMessageStore = create<MessageState>((set) => ({
@@ -32,7 +30,6 @@ export const useMessageStore = create<MessageState>((set) => ({
   hasMore: true,
   lastMessageId: null,
 
-  // 메시지 설정
   setMessages: (roomId: number, messages: MessageList) => {
     set((state) => ({
       messages: {
@@ -42,38 +39,20 @@ export const useMessageStore = create<MessageState>((set) => ({
     }));
   },
 
-  // 단일 메시지 추가 (새 메시지 수신 시)
   addMessage: (roomId: number, message: MessageRes) => {
     set((state) => {
       const existingMessages = state.messages[roomId] || [];
       const updatedMessages = [...existingMessages, message];
-
       return {
         messages: {
           ...state.messages,
           [roomId]: updatedMessages,
         },
-        // 현재 채팅방이면 currentRoomMessages도 업데이트
         currentRoomMessages: state.currentRoomId === roomId ? updatedMessages : state.currentRoomMessages,
       };
     });
   },
 
-  // 메시지들 추가 (초기 로드 시)
-  addMessages: (roomId: number, messages: MessageList) => {
-    set((state) => {
-      const existingMessages = state.messages[roomId] || [];
-      const updatedMessages = [...existingMessages, ...messages];
-      return {
-        messages: {
-          ...state.messages,
-          [roomId]: updatedMessages,
-        },
-      };
-    });
-  },
-
-  // 메시지들 앞에 추가 (이전 메시지 로드 시)
   prependMessages: (roomId: number, messages: MessageList) => {
     set((state) => {
       const existingMessages = state.messages[roomId] || [];
@@ -87,35 +66,29 @@ export const useMessageStore = create<MessageState>((set) => ({
     });
   },
 
-  // 현재 채팅방 메시지 설정
   setCurrentRoomMessages: (roomId: number) => {
     set((state) => ({
-      currentRoomId: roomId, // 현재 채팅방 ID 설정
+      currentRoomId: roomId,
       currentRoomMessages: state.messages[roomId] || [],
     }));
   },
 
-  // 로딩 상태 설정
   setLoading: (loading: boolean) => {
     set({ isLoading: loading });
   },
 
-  // 추가 로딩 상태 설정
   setLoadingMore: (loading: boolean) => {
     set({ isLoadingMore: loading });
   },
 
-  // 더 불러올 메시지가 있는지 설정
   setHasMore: (hasMore: boolean) => {
     set({ hasMore });
   },
 
-  // 마지막 메시지 ID 설정
   setLastMessageId: (messageId: string | null) => {
     set({ lastMessageId: messageId });
   },
 
-  // 특정 채팅방 메시지 초기화
   clearMessages: (roomId?: number) => {
     if (roomId) {
       set((state) => {
@@ -123,7 +96,6 @@ export const useMessageStore = create<MessageState>((set) => ({
         delete newMessages[roomId];
         return {
           messages: newMessages,
-          // 현재 채팅방을 초기화하는 경우에만 currentRoomMessages도 초기화
           currentRoomMessages: state.currentRoomId === roomId ? [] : state.currentRoomMessages,
           currentRoomId: state.currentRoomId === roomId ? null : state.currentRoomId,
         };
@@ -133,7 +105,6 @@ export const useMessageStore = create<MessageState>((set) => ({
     }
   },
 
-  // 모든 메시지 초기화
   clearAllMessages: () => {
     set({
       messages: {},

--- a/src/features/update-message/index.ts
+++ b/src/features/update-message/index.ts
@@ -2,3 +2,6 @@ export { MessageInput } from './ui/MessageInput';
 export { useSendMessage } from './model/sendMessage';
 export { useLoadMessage } from './model/loadMessage';
 export { useAckMessage } from './model/ackMessage';
+export { MessageBubble } from './ui/MessageBubble';
+export { groupMessages } from './lib/messageGrouping';
+export type { GroupedMessage } from './lib/messageGrouping';

--- a/src/features/update-message/lib/messageGrouping.ts
+++ b/src/features/update-message/lib/messageGrouping.ts
@@ -1,4 +1,4 @@
-import { MessageRes } from '../model/types';
+import { MessageRes } from '@/entities/message';
 
 export interface GroupedMessage {
   message: MessageRes;

--- a/src/features/update-message/model/ackMessage.ts
+++ b/src/features/update-message/model/ackMessage.ts
@@ -15,28 +15,21 @@ export const useAckMessage = () => {
   const ackMessage = useCallback(
     async (messageId: string) => {
       if (!currentUser) {
-        setError('사용자 정보를 찾을 수 없습니다.');
+        setError('사용자 정보 찾을 수 없음');
         return;
       }
-
-      // 이미 확인된 메시지인지 체크
       if (acknowledgedMessages.has(messageId)) {
-        console.log(`메시지 ${messageId}는 이미 읽음 확인되었습니다.`);
+        console.log(`메시지 ${messageId} 읽음 확인 완료`);
         return;
       }
-
       try {
         setIsAcknowledging(true);
         setError(null);
-
         const ackData: MessageAck = {
           messageId,
           userId: currentUser.id,
         };
-
-        console.log(`메시지 읽음 확인 시작:`, ackData);
-
-        // STOMP를 통해 읽음 확인 전송
+        console.log(`메시지 읽음 확인: ${ackData}`);
         if (client && client.connected) {
           client.publish({
             destination: '/app/message.ack',
@@ -48,15 +41,12 @@ export const useAckMessage = () => {
         } else {
           throw new Error('STOMP 클라이언트가 연결되지 않았습니다.');
         }
-
-        // 로컬에서 읽음 확인 상태 업데이트
         setAcknowledgedMessages((prev) => new Set([...prev, messageId]));
-
         console.log(`메시지 ${messageId} 읽음 확인 완료`);
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : '읽음 확인 중 오류가 발생했습니다.';
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '읽음 확인 중 오류 발생';
         setError(errorMessage);
-        console.error(`메시지 ${messageId} 읽음 확인 실패:`, err);
+        console.error(`메시지 ${messageId} 읽음 확인 실패:`, error);
       } finally {
         setIsAcknowledging(false);
       }
@@ -68,26 +58,20 @@ export const useAckMessage = () => {
   const ackMultipleMessages = useCallback(
     async (messageIds: string[]) => {
       if (!currentUser) {
-        setError('사용자 정보를 찾을 수 없습니다.');
+        setError('사용자 정보 찾을 수 없음');
         return;
       }
-
       if (messageIds.length === 0) return;
-
       try {
         setIsAcknowledging(true);
         setError(null);
-
-        console.log(`${messageIds.length}개 메시지 일괄 읽음 확인 시작`);
-
-        // 각 메시지에 대해 읽음 확인 전송
+        console.log(`${messageIds.length}개 메시지 일괄 읽음 확인`);
         if (client && client.connected) {
           const ackPromises = messageIds.map((messageId) => {
             const ackData: MessageAck = {
               messageId,
               userId: currentUser.id,
             };
-
             return client.publish({
               destination: '/app/message.ack',
               body: JSON.stringify(ackData),
@@ -96,23 +80,20 @@ export const useAckMessage = () => {
               },
             });
           });
-
           await Promise.all(ackPromises);
         } else {
           throw new Error('STOMP 클라이언트가 연결되지 않았습니다.');
         }
-
         setAcknowledgedMessages((prev) => {
           const newSet = new Set(prev);
           messageIds.forEach((id) => newSet.add(id));
           return newSet;
         });
-
         console.log(`${messageIds.length}개 메시지 일괄 읽음 확인 완료`);
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : '일괄 읽음 확인 중 오류가 발생했습니다.';
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '일괄 읽음 확인 중 오류 발생';
         setError(errorMessage);
-        console.error('일괄 읽음 확인 실패:', err);
+        console.error('일괄 읽음 확인 실패:', error);
       } finally {
         setIsAcknowledging(false);
       }
@@ -124,7 +105,7 @@ export const useAckMessage = () => {
   const ackAllUnreadMessages = useCallback(
     async (unreadMessageIds: string[]) => {
       if (unreadMessageIds.length === 0) {
-        console.log('읽지 않은 메시지가 없습니다.');
+        console.log('읽지 않은 메시지 없음');
         return;
       }
       await ackMultipleMessages(unreadMessageIds);
@@ -151,15 +132,6 @@ export const useAckMessage = () => {
     setError(null);
   }, []);
 
-  // 특정 메시지의 읽음 확인 상태 제거 (테스트용)
-  const removeAckStatus = useCallback((messageId: string) => {
-    setAcknowledgedMessages((prev) => {
-      const newSet = new Set(prev);
-      newSet.delete(messageId);
-      return newSet;
-    });
-  }, []);
-
   // 모든 읽음 확인 상태 초기화
   const clearAllAckStatus = useCallback(() => {
     setAcknowledgedMessages(new Set());
@@ -168,19 +140,15 @@ export const useAckMessage = () => {
   return {
     isAcknowledging, // 읽음 확인 상태
     error, // 에러 메시지
-    acknowledgedMessages: Array.from(acknowledgedMessages), // 읽음 확인 상태 목록
-
     ackMessage, // 단일 메시지 읽음 확인
     ackMultipleMessages, // 여러 메시지 일괄 읽음 확인
     ackAllUnreadMessages, // 채팅방의 모든 읽지 않은 메시지 읽음 확인
     isMessageAcknowledged, // 메시지 읽음 확인 상태 확인
-
     resetAckState, // 읽음 확인 상태 리셋
     resetError, // 에러 리셋
-    removeAckStatus, // 특정 메시지의 읽음 확인 상태 제거 (테스트용)
     clearAllAckStatus, // 모든 읽음 확인 상태 초기화
-
     currentUser, // 현재 사용자
     totalAcknowledged: acknowledgedMessages.size, // 읽음 확인 상태 개수
+    acknowledgedMessages: Array.from(acknowledgedMessages), // 읽음 확인 상태 목록
   };
 };

--- a/src/features/update-message/model/loadMessage.ts
+++ b/src/features/update-message/model/loadMessage.ts
@@ -1,10 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useMessageStore } from '@/entities/message';
-import { getMessageList, getMoreMessageList } from '@/entities/message';
+import { getMessageList, getMoreMessageList, useMessageStore } from '@/entities/message';
 
-export const useLoadMessage = (roomId: number, pageSize: number = 30) => {
+export const useLoadMessage = (roomId: number) => {
   const {
-    messages,
     currentRoomMessages,
     currentRoomId,
     isLoading,
@@ -25,103 +23,66 @@ export const useLoadMessage = (roomId: number, pageSize: number = 30) => {
   // 초기 메시지 로드
   const loadInitialMessages = useCallback(async () => {
     if (!roomId) return;
-
     try {
       setLoading(true);
       setError(null);
-
-      console.log(`채팅방 ${roomId} 초기 메시지 로드 시작`);
       const messageList = await getMessageList(roomId);
-
       if (messageList && Array.isArray(messageList)) {
-        const roomMessages = messageList;
+        const roomMessages = messageList.reverse();
         setMessages(roomId, roomMessages);
-        setCurrentRoomMessages(roomId);
-
-        // 페이지네이션 정보 설정
         if (roomMessages.length > 0) {
           setLastMessageId(roomMessages[0].messageId);
-          setHasMore(roomMessages.length >= pageSize);
+          setHasMore(!roomMessages[0].isEnd);
         } else {
           setHasMore(false);
         }
-
         console.log(`채팅방 ${roomId} 초기 메시지 ${roomMessages.length}개 로드 완료`);
       } else {
         setMessages(roomId, []);
-        setCurrentRoomMessages(roomId);
         setHasMore(false);
-        console.log(`채팅방 ${roomId}에 메시지가 없습니다.`);
       }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : '메시지 로드 중 오류가 발생했습니다.';
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : '메시지 로드 중 오류 발생';
       setError(errorMessage);
-      console.error(`채팅방 ${roomId} 초기 메시지 로드 실패:`, err);
+      console.error(`채팅방 ${roomId} 초기 메시지 로드 실패:`, error);
     } finally {
       setLoading(false);
     }
-  }, [roomId, pageSize, setMessages, setCurrentRoomMessages, setLastMessageId, setHasMore, setLoading]);
+  }, [roomId, setMessages, setLastMessageId, setHasMore, setLoading]);
 
-  // 추가 메시지 로드 (스크롤 시)
+  // 추가 메시지 로드
   const loadMoreMessages = useCallback(async () => {
     if (!roomId || !hasMore || isLoadingMore || !lastMessageId) return;
-
     try {
       setLoadingMore(true);
       setError(null);
-
-      console.log(`채팅방 ${roomId} 추가 메시지 로드 시작 (lastId: ${lastMessageId})`);
       const messageList = await getMoreMessageList(roomId, parseInt(lastMessageId));
-
       if (messageList && Array.isArray(messageList)) {
-        const newMessages = messageList;
-
+        const newMessages = messageList.reverse();
         if (newMessages.length > 0) {
-          // 새 메시지들을 기존 메시지 앞에 추가
           prependMessages(roomId, newMessages);
-
-          // 현재 채팅방이면 currentRoomMessages도 업데이트
-          if (currentRoomId === roomId) {
-            setCurrentRoomMessages(roomId);
-          }
-
-          // 페이지네이션 정보 업데이트
           setLastMessageId(newMessages[0].messageId);
-          setHasMore(newMessages.length >= pageSize);
-
+          setHasMore(!newMessages[0].isEnd);
           console.log(`채팅방 ${roomId} 추가 메시지 ${newMessages.length}개 로드 완료`);
         } else {
           setHasMore(false);
-          console.log(`채팅방 ${roomId} 더 이상 불러올 메시지가 없습니다.`);
         }
       }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : '추가 메시지 로드 중 오류가 발생했습니다.';
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : '추가 메시지 로드 중 오류 발생';
       setError(errorMessage);
-      console.error(`채팅방 ${roomId} 추가 메시지 로드 실패:`, err);
+      console.error(`채팅방 ${roomId} 추가 메시지 로드 실패:`, error);
     } finally {
       setLoadingMore(false);
     }
-  }, [
-    roomId,
-    hasMore,
-    isLoadingMore,
-    lastMessageId,
-    pageSize,
-    currentRoomId,
-    prependMessages,
-    setCurrentRoomMessages,
-    setLastMessageId,
-    setHasMore,
-    setLoadingMore,
-  ]);
+  }, [roomId, hasMore, isLoadingMore, lastMessageId, prependMessages, setLastMessageId, setHasMore, setLoadingMore]);
 
   // 새 메시지 수신 시 자동으로 currentRoomMessages 업데이트
   useEffect(() => {
-    if (messages[roomId] && currentRoomId === roomId) {
+    if (currentRoomId === roomId) {
       setCurrentRoomMessages(roomId);
     }
-  }, [messages, roomId, currentRoomId, setCurrentRoomMessages]);
+  }, [roomId, currentRoomId, setCurrentRoomMessages]);
 
   // 컴포넌트 마운트 시 초기 메시지 로드
   useEffect(() => {
@@ -136,16 +97,13 @@ export const useLoadMessage = (roomId: number, pageSize: number = 30) => {
   }, []);
 
   return {
-    messages: currentRoomMessages, // 현재 채팅방의 메시지 목록
-    isLoading, // 메시지 로딩 상태
-    isLoadingMore, // 추가 메시지 로딩 상태
-    hasMore, // 더 많은 메시지가 있는지 여부
-    error, // 에러 메시지
-
-    loadInitialMessages, // 초기 메시지 로드
-    loadMoreMessages, // 추가 메시지 로드
-    resetError, // 에러 리셋
-
-    totalMessageCount: currentRoomMessages.length, // 현재 채팅방의 메시지 개수
+    messages: currentRoomMessages,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadInitialMessages,
+    loadMoreMessages,
+    resetError,
   };
 };

--- a/src/features/update-message/model/sendMessage.ts
+++ b/src/features/update-message/model/sendMessage.ts
@@ -1,13 +1,12 @@
 import { useCallback, useState } from 'react';
 import { useStomp } from '@/shared/api/stomp';
-import { useMessageStore } from '@/entities/message';
 import { useUserStore } from '@/entities/user';
-import { MessageReq, MessageRes } from '@/entities/message';
+import { MessageReq } from '@/entities/message';
 
 export const useSendMessage = (roomId: number) => {
   const { client } = useStomp();
   const { currentUser } = useUserStore();
-  const { addMessage } = useMessageStore();
+  // const { addMessage } = useMessageStore();
 
   const [isSending, setIsSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -19,25 +18,18 @@ export const useSendMessage = (roomId: number) => {
         setError('메시지 내용을 입력해주세요.');
         return;
       }
-
       if (!currentUser) {
-        setError('사용자 정보를 찾을 수 없습니다.');
+        setError('사용자 정보 찾을 수 없음');
         return;
       }
-
       try {
         setIsSending(true);
         setError(null);
-
-        // 메시지 객체 생성
         const messageData: MessageReq = {
           chatRoomId: roomId,
           content: content.trim(),
         };
-
-        console.log(`메시지 전송 시작:`, messageData);
-
-        // STOMP를 통해 메시지 전송
+        console.log(`메시지 전송: ${messageData}`);
         if (client && client.connected) {
           client.publish({
             destination: '/app/chat.sendMessage',
@@ -49,39 +41,35 @@ export const useSendMessage = (roomId: number) => {
         } else {
           throw new Error('STOMP 클라이언트가 연결되지 않았습니다.');
         }
-
-        // 로컬에 즉시 메시지 추가 (낙관적 업데이트)
-        const optimisticMessage: MessageRes = {
-          messageId: `temp-${Date.now()}`, // 임시 ID
-          chatRoomId: roomId,
-          senderId: currentUser.id,
-          senderName: currentUser.name,
-          imageUrl: currentUser.imageUrl,
-          createdAt: new Date().toISOString(),
-          content: content.trim(),
-          isEnd: false,
-        };
-
-        addMessage(roomId, optimisticMessage);
-        console.log('메시지 전송 완료 (낙관적 업데이트)');
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : '메시지 전송 중 오류가 발생했습니다.';
+        // const optimisticMessage: MessageRes = {
+        //   messageId: `temp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+        //   chatRoomId: roomId,
+        //   senderId: currentUser.id,
+        //   senderName: currentUser.name,
+        //   imageUrl: currentUser.imageUrl,
+        //   createdAt: new Date().toISOString(),
+        //   content: content.trim(),
+        //   isEnd: false,
+        // };
+        // addMessage(roomId, optimisticMessage);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : '메시지 전송 중 오류 발생';
         setError(errorMessage);
-        console.error('메시지 전송 실패:', err);
+        console.error('메시지 전송 실패:', error);
       } finally {
         setIsSending(false);
       }
     },
-    [roomId, client, currentUser, addMessage],
+    [roomId, client, currentUser],
   );
 
-  // 메시지 전송 상태 리셋
+  // 메시지 전송 상태 초기화
   const resetSendState = useCallback(() => {
     setIsSending(false);
     setError(null);
   }, []);
 
-  // 에러 리셋
+  // 에러 초기화
   const resetError = useCallback(() => {
     setError(null);
   }, []);
@@ -95,14 +83,12 @@ export const useSendMessage = (roomId: number) => {
   );
 
   return {
-    isSending, // 메시지 전송 상태
-    error, // 에러 메시지
-    canSend: canSendMessage, // 메시지 전송 가능 여부
-
-    sendMessage, // 메시지 전송
-    resetSendState, // 메시지 전송 상태 리셋
-    resetError, // 에러 리셋
-
-    currentUser, // 현재 사용자
+    isSending,
+    error,
+    canSend: canSendMessage,
+    sendMessage,
+    resetError,
+    resetSendState,
+    currentUser,
   };
 };

--- a/src/features/update-message/ui/MessageBubble.tsx
+++ b/src/features/update-message/ui/MessageBubble.tsx
@@ -1,8 +1,10 @@
 import clsx from 'clsx';
-import { MessageRes } from '../model/types';
+import { MessageRes } from '@/entities/message';
 import { useUserStore } from '@/entities/user';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/Avatar';
 import { formatChatTime } from '@/shared/lib/dateUtils';
+import { useAckMessage } from '@/features/update-message';
+import { useEffect } from 'react';
 
 interface MessageBubbleProps {
   className?: string;
@@ -15,9 +17,17 @@ interface MessageBubbleProps {
 
 export const MessageBubble = (props: MessageBubbleProps) => {
   const { currentUser } = useUserStore();
+  const { ackMessage, isMessageAcknowledged } = useAckMessage();
   const { message, showAvatar, showName, showTime } = props;
 
   const isMyMessage = currentUser?.id === props.message.senderId;
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!isMessageAcknowledged(message.messageId) && !isMyMessage) {
+      ackMessage(message.messageId);
+    }
+  }, [message.messageId, isMyMessage]);
 
   return (
     <div

--- a/src/features/update-message/ui/MessageBubble.tsx
+++ b/src/features/update-message/ui/MessageBubble.tsx
@@ -22,11 +22,11 @@ export const MessageBubble = (props: MessageBubbleProps) => {
 
   const isMyMessage = currentUser?.id === props.message.senderId;
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!isMessageAcknowledged(message.messageId) && !isMyMessage) {
       ackMessage(message.messageId);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [message.messageId, isMyMessage]);
 
   return (

--- a/src/features/update-message/ui/MessageInput.tsx
+++ b/src/features/update-message/ui/MessageInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { useSendMessage } from '../model/sendMessage';
+import { useSendMessage } from '@/features/update-message';
 import { Button } from '@/shared/ui/Button';
 import { Input } from '@/shared/ui/Input';
 import { Send } from 'lucide-react';

--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { tokenEventBus } from '../lib/tokenEventBus';
 
 interface ExtendedAxiosRequestConfig extends InternalAxiosRequestConfig {
   _retry?: boolean;
@@ -49,6 +50,8 @@ api.interceptors.response.use(
 
         if (typeof window !== 'undefined') {
           localStorage.setItem('accessToken', accessToken);
+          tokenEventBus.emit(accessToken);
+          console.log('accessToken 재발급 및 이벤트 수신 완료: ', accessToken);
         }
 
         originalRequest.headers.set('Authorization', `Bearer ${accessToken}`);

--- a/src/shared/lib/tokenEventBus.ts
+++ b/src/shared/lib/tokenEventBus.ts
@@ -1,0 +1,18 @@
+type TokenChangeListener = (newToken: string) => void;
+
+class TokenEventBus {
+  private listeners: TokenChangeListener[] = [];
+
+  subscribe(listener: TokenChangeListener) {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+
+  emit(newToken: string) {
+    this.listeners.forEach((listener) => listener(newToken));
+  }
+}
+
+export const tokenEventBus = new TokenEventBus();

--- a/src/widgets/message/ui/MessageScrollArea.tsx
+++ b/src/widgets/message/ui/MessageScrollArea.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { MessageBubble, groupMessages } from '@/entities/message';
+import { MessageBubble, groupMessages } from '@/features/update-message';
 import { useLoadMessage } from '@/features/update-message';
 import { ScrollArea } from '@/shared/ui/ScrollArea';
 
@@ -14,6 +14,12 @@ export const MessageScrollArea = ({ roomId, className }: MessageScrollAreaProps)
   const scrollRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading, isLoadingMore, hasMore, error, loadMoreMessages } = useLoadMessage(roomId);
 
+  const scrollToBottom = () => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  };
+
   // 스크롤 이벤트 처리 (무한 스크롤)
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const { scrollTop } = e.currentTarget;
@@ -22,13 +28,19 @@ export const MessageScrollArea = ({ roomId, className }: MessageScrollAreaProps)
     }
   };
 
+  useEffect(() => {
+    if (messages.length > 0 && isLoading) {
+      scrollToBottom();
+    }
+  }, [messages.length, isLoading]);
+
   // 새 메시지가 추가되면 자동으로 하단으로 스크롤
   useEffect(() => {
     if (scrollRef.current && messages.length > 0) {
-      const isAtBottom =
-        scrollRef.current.scrollTop + scrollRef.current.clientHeight >= scrollRef.current.scrollHeight - 100;
+      const { scrollTop, clientHeight, scrollHeight } = scrollRef.current;
+      const isAtBottom = scrollTop + clientHeight >= scrollHeight - 100;
       if (isAtBottom) {
-        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        scrollToBottom();
       }
     }
   }, [messages.length]);


### PR DESCRIPTION
# 채팅방 기능 고도화 1차
- 메시지 2중 생성을 막기 위해 전송 메시지 낙관적 UI 반영 기능을 임시로 주석처리했습니다.
- MessageBubble 컴포넌트를 비즈니스 로직 결합에 따라 features 레이어로 이동시켰습니다.
    - 메시지 그루핑 유틸도 포함하여 이동되었습니다.
- 채팅방 기능 관련 비즈니스 로직들에 구현되었으나 필요없거나 테스트용 함수를 제거했습니다.
- 채팅방 스크롤을 통한 추가 메시지 요청 로직을 보강했습니다.
- 페이지네이션을 위한 isEnd 플래그 컬럼을 정상적으로 활용하도록 수정했습니다.

# stomp 클라이언트 관련 워크 플로우 수정
- 엑세스 토큰이 만료되어 재발급되는 경우, 기존에 생성되었던 stomp client 가 유효하지않는 싱크 문제를 해결했습니다.
    - shared 레이어에 엑세스 토큰 재발급을 감지하는 token event bus 유틸을 추가하였습니다.
    - axios 인스턴스가 access token 재발급시 이벤트를 발생시키도록 구성했습니다.
    - stomp provider 가 이벤트 수신시 stomp client 를 새 access token 으로 다시 생성하도록 구성했습니다.
        - client 생성 과정을 함수화 하고 서비스 초기 랜딩시 생성과 재생성으로 분리하였습니다.