### PR TITLE
HOTFIX/#59 message 응답값 interface 타입 불일치 해결

### DIFF
--- a/src/entities/message/model/types.ts
+++ b/src/entities/message/model/types.ts
@@ -8,7 +8,7 @@ export interface MessageRes {
   chatRoomId: number;
   senderId: number;
   senderName: string;
-  imageUrl: string;
+  senderImageUrl: string;
   createdAt: string;
   content: string;
   isEnd: boolean;

--- a/src/features/update-message/ui/MessageBubble.tsx
+++ b/src/features/update-message/ui/MessageBubble.tsx
@@ -40,7 +40,7 @@ export const MessageBubble = (props: MessageBubbleProps) => {
           {showAvatar && (
             <div className="flex-shrink-0">
               <Avatar className="size-10">
-                <AvatarImage src={message.imageUrl} alt={message.senderName} />
+                <AvatarImage src={message.senderImageUrl} alt={message.senderName} />
                 <AvatarFallback className="text-xs">{message.senderName.charAt(0)}</AvatarFallback>
               </Avatar>
             </div>


### PR DESCRIPTION
# message resposne 타입 불일치 hotfix
- 백엔드에서 응답하는 message entity 에 대한 interface 타입 불일치를 수정했습니다.
    - imageUrl -> senderImageUrl