### PR TITLE
Fix/#26 onboarding fix

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,3 +1,4 @@
+'use client';
 export default function LoadingPage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">

--- a/src/entities/user/api/getUserProfile.ts
+++ b/src/entities/user/api/getUserProfile.ts
@@ -1,0 +1,7 @@
+import api from '@/shared/api/axios';
+import { UserProfile } from '../model/types';
+
+export const getUserProfile = async () => {
+  const response = await api.get<UserProfile>('/users/profile');
+  return response.data;
+};

--- a/src/entities/user/lib/onboardingDataMapper.ts
+++ b/src/entities/user/lib/onboardingDataMapper.ts
@@ -15,16 +15,14 @@ export const onboardingDataMapper = (bundle: OnboardingData): DrawerConfig[] => 
   },
   {
     key: 'position',
-    label: '꿈꾸는 커리어를 선택해주세요',
-    placeholder: '관심있는 커리어 방향을 선택해주세요',
-    contentHeader: '꿈꾸는 커리어 영역을 선택해주세요',
+    label: '꿈꾸는 커리어 영역',
+    placeholder: '관심있는 커리어 영역을 선택해주세요',
     items: bundle.positions,
   },
   {
     key: 'preferenceType',
-    label: '같이 이야기하고 싶은 친구를 선택해주세요',
-    placeholder: '만나고 싶은 친구 유형을 선택해주세요',
-    contentHeader: '토킷 안에서 친구들과 이런 주제로 이야기하고 싶어요',
+    label: '관심있는 대화 주제',
+    placeholder: '관심있는 대화 주제를 선택해주세요',
     items: bundle.preferenceType,
   },
 ];

--- a/src/entities/user/lib/validators.ts
+++ b/src/entities/user/lib/validators.ts
@@ -19,7 +19,7 @@ export const step2Schema = z.object({
 export const step3Schema = z.object({
   bio: z
     .string()
-    .min(5, { message: '최소 10글자의 메세지를 작성해주세요.' })
+    .min(5, { message: '최소 5자의 메세지를 작성해주세요.' })
     .max(30, { message: '최대 30자까지 작성 가능합니다' }),
   images: z.array(z.any()).max(3, '이미지는 최대 3장까지 가능합니다.'),
 });

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -26,7 +26,6 @@ export interface DrawerConfig<K extends EnumKey = EnumKey> {
   key: K;
   label: string;
   placeholder: string;
-  contentHeader?: string;
   items: Option[];
 }
 

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -6,6 +6,18 @@ export interface User {
   isOnboardingCompleted: boolean;
 }
 
+export interface UserProfile {
+  userId: number;
+  nickname: string;
+  university: string;
+  isUniversityVisible: boolean;
+  position: string;
+  imageUrls: string[];
+  bio: string;
+  focusType: string;
+  isLikedByMe: boolean;
+}
+
 // onboarding enums 타입 정의
 type Option = {
   code: string;

--- a/src/features/update-user/model/userOnboarding.ts
+++ b/src/features/update-user/model/userOnboarding.ts
@@ -24,6 +24,7 @@ export function useOptionFilter() {
 
   const step2Configs = useMemo(
     () => configs.filter((c) => dataKey.includes(c.key as Step2FormKey)) as DrawerConfig<Step2FormKey>[],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [configs],
   );
 

--- a/src/features/update-user/model/userOnboarding.ts
+++ b/src/features/update-user/model/userOnboarding.ts
@@ -11,7 +11,7 @@ import { updateOnboarding } from '../api/updateOnboarding';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 
-export function useOptionFilter() {
+export const useOptionFilter = () => {
   const { data: bundle } = useOnboardingData();
   // const bundle = sampleData; // mock
   const configs = useMemo(() => (bundle ? onboardingDataMapper(bundle) : []), [bundle]);
@@ -29,7 +29,7 @@ export function useOptionFilter() {
   );
 
   return { bundle, configs, uniConfig, genderOptions, step2Configs };
-}
+};
 
 export const finalOnboardingDataMapper = (data: AllFormData, imageIds: number[]) => {
   return {
@@ -47,7 +47,7 @@ export const finalOnboardingDataMapper = (data: AllFormData, imageIds: number[])
   };
 };
 
-export function useSubmitOnboarding() {
+export const useSubmitOnboarding = () => {
   const router = useRouter();
   return useMutation({
     mutationFn: async () => {
@@ -73,4 +73,4 @@ export function useSubmitOnboarding() {
       throw err;
     },
   });
-}
+};

--- a/src/features/update-user/ui/DrawerSelect.tsx
+++ b/src/features/update-user/ui/DrawerSelect.tsx
@@ -7,7 +7,6 @@ import { cn } from '@/shared/lib/tailwindMerge';
 interface DrawerSelectProps<T = string> {
   label: string; // Form label
   placeholder: string; // Button placeholder
-  contentHeader?: string; // Drawer 내부 헤더
   value: T | null;
   renderOptions: (temp: T | null, setTemp: (v: T) => void) => React.ReactNode;
   onConfirm: (value: T) => void;
@@ -16,7 +15,6 @@ interface DrawerSelectProps<T = string> {
 export const DrawerSelect = <T extends string>({
   label,
   placeholder,
-  contentHeader,
   value,
   renderOptions,
   onConfirm,
@@ -41,8 +39,8 @@ export const DrawerSelect = <T extends string>({
   };
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-[14px]">
+    <>
+      <div className="flex items-center gap-2">
         <div className="text-base font-semibold">{label}</div>
       </div>
       <Drawer open={open} onOpenChange={handleOpenChange}>
@@ -50,20 +48,35 @@ export const DrawerSelect = <T extends string>({
         <DrawerTrigger asChild>
           <Button
             variant="drawerSelect"
+            size="drawerSelect"
             className={cn('w-full justify-between text-base text-stone-600', !value && 'text-stone-500')}
           >
             {value || placeholder}
-            <ChevronDown className="size-4" />
+            <ChevronDown className="size-6" />
           </Button>
         </DrawerTrigger>
         <DrawerContent className="space-y-5 px-8">
-          <div className="text-2xl font-medium">{contentHeader || label}</div>
+          <div className="text-2xl font-bold text-stone-600">
+            {label === 'MBTI' ? (
+              <>
+                자신의 <span className="text-stone-900">MBTI</span>를 선택해주세요
+              </>
+            ) : label === '꿈꾸는 커리어 영역' ? (
+              <>
+                꿈꾸는 <span className="text-stone-900">커리어 영역</span>를<br /> 선택해주세요
+              </>
+            ) : (
+              <>
+                관심있는 <span className="text-stone-900">대화 주제</span>를<br /> 선택해주세요
+              </>
+            )}
+          </div>
           {renderOptions(temp, setTemp)}
           <Button onClick={handleConfirm} className="my-2 w-full">
             확인
           </Button>
         </DrawerContent>
       </Drawer>
-    </div>
+    </>
   );
 };

--- a/src/features/update-user/ui/ImageUploader.tsx
+++ b/src/features/update-user/ui/ImageUploader.tsx
@@ -49,9 +49,9 @@ export function ImageUploader({ value, onChange, maxFiles = 3, maxSizeMB = 5, cl
 
     if (!res.ok) {
       if (res.error === 'TOO_MANY_FILES') {
-        toast.error(`최대 ${maxFiles}장까지만 업로드 가능합니다.`);
+        toast.error(`최대 ${maxFiles}장까지만 업로드 가능합니다`);
       } else if (res.error === 'FILE_TOO_LARGE') {
-        toast.error(`파일 크기는 최대 ${maxSizeMB}MB 미만이어야 합니다.`);
+        toast.error(`파일 크기가 ${maxSizeMB}MB 이상으로 업로드 불가합니다`);
       }
       resetInput();
       return;
@@ -73,18 +73,20 @@ export function ImageUploader({ value, onChange, maxFiles = 3, maxSizeMB = 5, cl
       {/* 썸네일 리스트 */}
       <div className="flex flex-wrap gap-3">
         {previews.map((p, i) => (
-          <div key={i} className="relative h-24 w-24 overflow-hidden rounded-md border">
-            {/* 대표 태그: 첫 번째 */}
-            {i === 0 && (
-              <span className="absolute top-1 left-1 z-10 rounded bg-black/70 px-1.5 py-0.5 text-[10px] text-white">
-                대표
-              </span>
-            )}
-            <Image src={p.url} alt={`preview-${i}`} className="h-full w-full object-cover" width="96" height="96" />
+          <div key={i} className="relative">
+            <div className="rounded-20 relative h-[110px] w-[110px] overflow-hidden border">
+              {/* 대표 태그: 첫 번째 */}
+              {i === 0 && (
+                <div className="absolute bottom-0 z-10 w-full bg-stone-900 px-1.5 py-1.5 text-center text-xs font-bold text-stone-100">
+                  대표 사진
+                </div>
+              )}
+              <Image src={p.url} alt={`preview-${i}`} className="h-full w-full object-cover" width="110" height="110" />
+            </div>
             {/* 삭제 버튼 */}
             <button
               type="button"
-              className="absolute -top-2 -right-2 rounded-full bg-white p-1 shadow"
+              className="absolute -top-2 -right-1 rounded-full bg-stone-900 p-0.5 text-stone-100"
               onClick={() => handleRemove(i)}
               aria-label="삭제"
             >
@@ -98,7 +100,7 @@ export function ImageUploader({ value, onChange, maxFiles = 3, maxSizeMB = 5, cl
           <button
             type="button"
             onClick={handleClickAdd}
-            className="hover:bg-muted/50 flex h-24 w-24 items-center justify-center rounded-md border"
+            className="hover:bg-muted/50 rounded-20 flex h-[110px] w-[110px] items-center justify-center border border-stone-400 text-stone-400"
             aria-label="이미지 추가"
           >
             <Plus className="h-6 w-6" />
@@ -115,7 +117,7 @@ export function ImageUploader({ value, onChange, maxFiles = 3, maxSizeMB = 5, cl
         className="hidden"
         onChange={(e) => handleFiles(e.target.files)}
       />
-      <p className="text-muted-foreground text-xs">
+      <p className="text-sm text-stone-400">
         * 사진은 최대 {maxFiles}장 가능, 용량은 1장당 {maxSizeMB}MB 미만 가능합니다
       </p>
     </div>

--- a/src/features/update-user/ui/Step2Form.tsx
+++ b/src/features/update-user/ui/Step2Form.tsx
@@ -9,7 +9,7 @@ import type { Step2Data, StepFormHandle } from '@/entities/user/model/types';
 import { useOptionFilter } from '../model/userOnboarding';
 
 import { Badge } from '@/shared/ui/Badge';
-import { DrawerSelect } from '@/entities/user/ui/DrawerSelect';
+import { DrawerSelect } from '@/features/update-user/ui/DrawerSelect';
 import { preferenceLableMapper } from '@/entities/user/lib/onboardingDataMapper';
 import { cn } from '@/shared/lib/tailwindMerge';
 
@@ -50,7 +50,7 @@ export const Step2Form = forwardRef<StepFormHandle, Step2FormProps>(function Ste
 
   return (
     <form className="space-y-5" onSubmit={(e) => e.preventDefault()}>
-      {step2Configs.map(({ key, label, placeholder, contentHeader, items }) => {
+      {step2Configs.map(({ key, label, placeholder, items }) => {
         return (
           <div key={key} className="space-y-2">
             <Controller
@@ -60,18 +60,18 @@ export const Step2Form = forwardRef<StepFormHandle, Step2FormProps>(function Ste
                 <DrawerSelect
                   label={label}
                   placeholder={placeholder}
-                  contentHeader={contentHeader}
                   value={field.value || ''}
                   onConfirm={field.onChange}
                   renderOptions={(selected, setSelected) => (
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex h-[250px] flex-wrap content-start gap-2">
                       {items.map((opt) => {
                         const lableText = key === 'preferenceType' ? preferenceLableMapper(opt.name) : opt.name;
                         return (
                           <Badge
                             key={opt.code}
                             className={cn(
-                              'cursor-pointer px-4 py-2',
+                              'cursor-pointer py-2.5',
+                              key === 'mbti' ? 'w-[75px] text-center' : 'px-6',
                               selected === opt.name ? 'bg-primary font-bold text-stone-100' : '',
                             )}
                             onClick={() => setSelected(opt.name)}

--- a/src/features/update-user/ui/Step3Form.tsx
+++ b/src/features/update-user/ui/Step3Form.tsx
@@ -39,7 +39,7 @@ export const Step3Form = forwardRef<StepFormHandle, Step3FormProps>(function Ste
   const { errors } = form.formState;
 
   return (
-    <form className="space-y-6 px-4" onSubmit={(e) => e.preventDefault()}>
+    <form className="space-y-7" onSubmit={(e) => e.preventDefault()}>
       {/* 이미지 업로더 */}
       <Controller
         name="images"
@@ -59,12 +59,13 @@ export const Step3Form = forwardRef<StepFormHandle, Step3FormProps>(function Ste
       {errors.images?.message && <p className="text-sm text-red-500">{errors.images.message as string}</p>}
       {/* 소개 텍스트 */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">저는</Label>
+        <Label className="text-lg font-semibold text-stone-900">자신을 소개해주세요</Label>
         <Textarea
           placeholder="예시. 데이터와 디자인을 모두 좋아하는 23살 대학생입니다. 다양한 전공의 사람들과 협업해보고 싶어요."
           {...form.register('bio')}
           rows={5}
         />
+        <p className="text-right text-sm text-stone-400">최소 5자 ~ 최대 30자</p>
         {errors.bio?.message && <p className="text-sm text-red-500">{errors.bio.message as string}</p>}
       </div>{' '}
     </form>

--- a/src/shared/ui/Badge.tsx
+++ b/src/shared/ui/Badge.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/shared/lib/tailwindMerge';
 
 const badgeVariants = cva(
-  'inline-flex items-center justify-center rounded-20 border px-2 py-0.5 text-base font-normal w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  'inline-flex items-center justify-center rounded-20 border px-2 py-0.5 text-base font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -23,6 +23,7 @@ const buttonVariants = cva(
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-6 rounded-md',
+        drawerSelect: 'px-2 py-[10.5px]',
       },
     },
     defaultVariants: {

--- a/src/shared/ui/Drawer.tsx
+++ b/src/shared/ui/Drawer.tsx
@@ -48,7 +48,7 @@ function DrawerContent({ className, children, ...props }: React.ComponentProps<t
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          'group/drawer-content bg-background absolute z-50 mx-auto flex h-auto max-w-[480px] min-w-xs flex-col',
+          'group/drawer-content absolute z-50 mx-auto flex h-auto max-w-[480px] min-w-xs flex-col bg-stone-300',
           'data-[vaul-drawer-direction=top]:rounded-b-20 data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:border-b',
           'data-[vaul-drawer-direction=bottom]:rounded-t-20 data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:border-t',
           'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
@@ -57,7 +57,6 @@ function DrawerContent({ className, children, ...props }: React.ComponentProps<t
         )}
         {...props}
       >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {/* handle */}
         <div className="mx-auto mt-3 mb-8 h-1 w-12.5 flex-shrink-0 rounded-full bg-black" />
         {children}

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
     <textarea
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 rounded-20 flex field-sizing-content min-h-16 w-full bg-stone-100 px-3 py-2 text-base font-semibold transition-[color,box-shadow] outline-none placeholder:text-sm placeholder:font-medium placeholder:text-stone-400 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/src/views/auth/ui/OnboardingEndPage.tsx
+++ b/src/views/auth/ui/OnboardingEndPage.tsx
@@ -21,7 +21,7 @@ export default function OnboardingEndPage({ delayMs = 3000 }: { delayMs?: number
     return () => clearTimeout(t);
   }, [delayMs]);
 
-  if (!user) return LoadingPage;
+  if (!user) return <LoadingPage />;
 
   return (
     <div

--- a/src/views/auth/ui/OnboardingEndPage.tsx
+++ b/src/views/auth/ui/OnboardingEndPage.tsx
@@ -1,33 +1,44 @@
 'use client';
+import LoadingPage from '@/app/loading';
+import { getUserProfile } from '@/entities/user/api/getUserProfile';
+import { UserProfile } from '@/entities/user/model/types';
 import { cn } from '@/shared/lib/tailwindMerge';
 import { Button } from '@/shared/ui/Button';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 export default function OnboardingEndPage({ delayMs = 3000 }: { delayMs?: number }) {
-  const [step, setStep] = useState<'splash' | 'detail'>('splash');
+  const [step, setStep] = useState<'splash' | 'detail' | 'profile'>('splash');
+  const [user, setUser] = useState<UserProfile | null>(null);
   const router = useRouter();
+
+  useEffect(() => {
+    getUserProfile().then(setUser).catch(console.error);
+  }, []);
 
   useEffect(() => {
     const t = setTimeout(() => setStep('detail'), delayMs);
     return () => clearTimeout(t);
   }, [delayMs]);
 
+  if (!user) return LoadingPage;
+
   return (
     <div
       className={cn(
         'font-display-lg flex h-screen flex-col justify-center px-4 text-center align-middle text-stone-900',
-        step === 'detail' && 'relative',
+        step !== 'splash' && 'relative',
       )}
     >
-      {step === 'splash' ? (
+      {step === 'splash' && (
         <>
-          <div>{}님</div>
+          <div>{user.nickname}님</div>
           <div>
             <span className="text-primary">커피챗</span> 하실래요?
           </div>
         </>
-      ) : (
+      )}
+      {step === 'detail' && (
         <>
           <div className="text-xl">
             <div className="text-primary">커피챗이란?</div>
@@ -37,8 +48,16 @@ export default function OnboardingEndPage({ delayMs = 3000 }: { delayMs?: number
             <div>진로 고민, 일상 이야기까지</div>
             <div>지금 대화를 나눠보세요!</div>
           </div>
-          <Button className="absolute bottom-3 w-11/12" onClick={() => router.push('/explore')}>
+          <Button className="absolute bottom-3 w-11/12" onClick={() => setStep('profile')}>
             완성된 프로필 확인하기
+          </Button>
+        </>
+      )}
+      {step === 'profile' && (
+        <>
+          <div>{user.nickname}님 프로필카드</div>
+          <Button className="absolute bottom-3 w-11/12" onClick={() => router.push('/explore')}>
+            시작하기
           </Button>
         </>
       )}

--- a/src/widgets/onboarding/ui/OnboardingFunnel.tsx
+++ b/src/widgets/onboarding/ui/OnboardingFunnel.tsx
@@ -7,7 +7,7 @@ import { StepRender } from './StepRender';
 import { PROGRESS_BY_STEP } from '@/shared/constants';
 import { Progress } from '@/shared/ui/Progress';
 import { Button } from '@/shared/ui/Button';
-import { ArrowLeft } from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
 
 import { useSubmitOnboarding } from '@/features/update-user/model/userOnboarding';
 
@@ -64,8 +64,8 @@ export const OnboardingFunnel = ({ initialStep = 1 }: { initialStep?: number }) 
       <div>
         <header className="sticky top-0 z-10 flex h-(--space-h-header) items-center justify-center pt-3 pb-2.5">
           {step > 1 && (
-            <Button variant="ghost" size="icon" onClick={goPrev} className="absolute left-4">
-              <ArrowLeft className="size-6" />
+            <Button variant="ghost" size="icon" onClick={goPrev} className="absolute left-0">
+              <ChevronLeft className="size-6" />
             </Button>
           )}
           <h2 className="text-xl font-semibold text-stone-900">프로필 만들기</h2>


### PR DESCRIPTION
## 온보딩 페이지 내 디자인 및 문구를 전반적으로 수정하였습니다.

## 파일 이동
- drawerSelect 를 features 폴더 하위로 옮겼습니다.
- ts 파일 이슈로 mapper 에 작성한 contentHeader 프롭스로는 디자인 적용이 어려워 drawerSelect 구조에서 삭제하였습니다..
>  이 부분은 차후.. 좀 더 고민해봐야 할 듯 합니다ㅠㅠ

## 빌드 워닝 예외처리
- useMemo 에서 워닝 뜨던 사항을 주석으로 예외처리 하였습니다.

## 유저프로필 api 연동
- api 로 가져와서 온보딩 완료 페이지에서 닉네임이 나오도록 수정하였습니다.
- 프로필 보기 클릭시 프로필 카드 step으로 이동하도록 임시 조치 하였습니다.
> 해당 페이지 ui는 차후 영우님 개발건에서 가져와 붙이도록 하겠습니다.

## 온보딩 페이지 진행 시 오류 수정
- 자기소개 문구 작성에 '최소 10글자'에서 5글자로 유효성 검사를 수정하였습니다.