### PR TITLE
HOTFIX/#69 쿼리 페이징 처리 단순화

### DIFF
--- a/src/entities/message/api/useMessageQuery.ts
+++ b/src/entities/message/api/useMessageQuery.ts
@@ -1,4 +1,3 @@
-import { MESSAGE_PAGE_SIZE } from '@/shared/constants';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { MessageList, getMessageList, getMoreMessageList } from '..';
 
@@ -10,22 +9,24 @@ export const useMessageQuery = (roomId: number) => {
       return pageParam == null ? getMessageList(roomId) : getMoreMessageList(roomId, pageParam as string);
     },
     getNextPageParam: (lastPage) => {
-      if (!lastPage || lastPage.length < MESSAGE_PAGE_SIZE) return undefined;
+      if (!lastPage || lastPage.length === 0) return undefined;
       if (lastPage.some((m) => m.isEnd)) return undefined;
       return lastPage[lastPage.length - 1].messageId;
     },
     select: (data) => {
       const seen = new Set<string>();
-      const pages = data.pages.map((items) => {
-        const out: MessageList = [];
-        for (const m of items) {
-          if (!seen.has(m.messageId)) {
-            seen.add(m.messageId);
-            out.push(m);
+      const pages = data.pages
+        .map((items) => {
+          const out: MessageList = [];
+          for (const m of items) {
+            if (!seen.has(m.messageId)) {
+              seen.add(m.messageId);
+              out.push(m);
+            }
           }
-        }
-        return out;
-      });
+          return out;
+        })
+        .filter((p) => p.length > 0);
       return { ...data, pages } as typeof data;
     },
     staleTime: 30_000, // 30초

--- a/src/features/update-chat/lib/pushLiveMessage.ts
+++ b/src/features/update-chat/lib/pushLiveMessage.ts
@@ -1,5 +1,4 @@
 import { MessageRes } from '@/entities/message';
-import { MESSAGE_PAGE_SIZE } from '@/shared/constants';
 import { QueryClient } from '@tanstack/react-query';
 
 export function pushLiveMessage(qc: QueryClient, roomId: number, msg: MessageRes) {
@@ -7,7 +6,6 @@ export function pushLiveMessage(qc: QueryClient, roomId: number, msg: MessageRes
   qc.setQueryData<any>(key, (old: any) => {
     if (!old) return old;
     const pages: MessageRes[][] = Array.isArray(old.pages) ? old.pages.map((p: MessageRes[]) => [...p]) : [[]];
-    const pageParams = Array.isArray(old.pageParams) ? [...old.pageParams] : [];
     for (const p of pages) {
       if (p.some((m) => m.messageId === msg.messageId)) {
         return old;
@@ -15,18 +13,6 @@ export function pushLiveMessage(qc: QueryClient, roomId: number, msg: MessageRes
     }
     if (!pages.length) pages.push([]);
     pages[0].unshift(msg);
-    let i = 0;
-    while (i < pages.length) {
-      if (pages[i].length <= MESSAGE_PAGE_SIZE) break;
-      const overflow = pages[i].splice(MESSAGE_PAGE_SIZE);
-      if (pages[i + 1]) {
-        pages[i + 1] = [...overflow, ...pages[i + 1]];
-      } else {
-        pages[i + 1] = overflow;
-        pageParams[i + 1] = pageParams.length ? pageParams[pageParams.length - 1] : null;
-      }
-      i++;
-    }
-    return { ...old, pages, pageParams };
+    return { ...old, pages };
   });
 }

--- a/src/shared/constants/constant.ts
+++ b/src/shared/constants/constant.ts
@@ -9,5 +9,4 @@ export const PROGRESS_BY_STEP: Record<number, number> = {
   3: 100,
 };
 
-export const MESSAGE_PAGE_SIZE = 30 as const;
 export const MESSAGE_MAX_LEN = 300;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,4 +1,3 @@
 export { SERVICE_INFO } from './constant';
 export { PROGRESS_BY_STEP } from './constant';
-export { MESSAGE_PAGE_SIZE } from './constant';
 export { MESSAGE_MAX_LEN } from './constant';


### PR DESCRIPTION
# 쿼리 페이지 처리 단순화 처리 HOTFIX
- 쿼리에 대한 실시간 데이터 캐싱 병합 로직을 단순화했습니다.
- 추후 과도한 메모리 점유 이슈 해결 방안이 필요합니다.