### PR TITLE
fix/#102 온보딩 유효성 검증 이슈 수정

### DIFF
--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { clearUserData, getCurrentUser } from '@/entities/user';
+import { LoadingSpinner } from '@/shared/ui/LoadingSpinner';
 import { OnboardingPage } from '@/views/auth/ui/OnboardingPage';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -26,6 +27,6 @@ export default function Page() {
     checkOnboarding();
   }, [router]);
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) return <LoadingSpinner fullScreen />;
   return <OnboardingPage />;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -215,9 +215,9 @@
 
   .scrollbar-hide {
     &::-webkit-scrollbar {
-      display: none;
+      display: none !important;
     }
-    scrollbar-width: none;
+    scrollbar-width: none !important;
   }
 
   .safe-pt {

--- a/src/entities/user/lib/validators.ts
+++ b/src/entities/user/lib/validators.ts
@@ -22,9 +22,12 @@ export const step2Schema = z.object({
 export const step3Schema = z.object({
   bio: z
     .string()
-    .min(5, { message: '최소 5자의 메세지를 작성해주세요.' })
+    .min(5, { message: '최소 5자의 메세지를 작성해주세요' })
     .max(30, { message: '최대 30자까지 작성 가능합니다' }),
-  images: z.array(z.any()).max(3, '이미지는 최대 3장까지 가능합니다.'),
+  images: z
+    .array(z.any())
+    .min(1, { message: '최소 1장의 이미지는 필수로 업로드 해주세요' })
+    .max(3, { message: '이미지는 최대 3장까지 가능합니다' }),
 });
 
 export const getSchemaByStep = (step: number) => {

--- a/src/features/update-user/model/userImageUpload.ts
+++ b/src/features/update-user/model/userImageUpload.ts
@@ -1,9 +1,11 @@
 export interface UploadConfig {
   maxFiles: number;
   maxSizeMB: number;
+  allowedExt?: readonly string[];
+  allowedMime?: readonly string[];
 }
 
-export type UploadError = 'TOO_MANY_FILES' | 'FILE_TOO_LARGE';
+export type UploadError = 'TOO_MANY_FILES' | 'FILE_TOO_LARGE' | 'INVALID_TYPE';
 export type ValidateResult = { ok: true; next: File[] } | { ok: false; error: UploadError };
 
 export function validateAndMergeFiles(current: File[], incoming: File[] | FileList, cfg: UploadConfig): ValidateResult {
@@ -29,4 +31,71 @@ export function validateAndMergeFiles(current: File[], incoming: File[] | FileLi
   }
 
   return { ok: true, next: merged };
+}
+
+// 이미지 파일 제한 버전 검증
+export type RejectReason = 'INVALID_TYPE' | 'FILE_TOO_LARGE';
+export interface RejectItem {
+  name: string;
+  reason: RejectReason;
+  size?: number; // bytes
+  type?: string; // mime
+}
+export type ValidateResultV2 = { ok: true; next: File[] } | { ok: false; error: UploadError; rejects: RejectItem[] };
+
+function getExt(file: File) {
+  return file.name.split('.').pop()?.toLowerCase();
+}
+
+function isAllowedByType(file: File, allowedExt?: readonly string[], allowedMime?: readonly string[]) {
+  const ext = getExt(file);
+  const byExt = !!ext && !!allowedExt && allowedExt.includes(ext);
+  const byMime = !!allowedMime && allowedMime.includes(file.type as any);
+  // 둘 중 하나라도 허용되면 OK (운영 정책에 따라 AND로 바꿔도 됨)
+  return allowedExt || allowedMime ? byExt || byMime : true;
+}
+
+export function validateAndMergeFilesV2(
+  current: File[],
+  incoming: File[] | FileList,
+  cfg: UploadConfig,
+): ValidateResultV2 {
+  const arr = Array.from(incoming);
+  const limitBytes = cfg.maxSizeMB * 1024 * 1024;
+  const rejects: RejectItem[] = [];
+  const valids: File[] = [];
+
+  for (const f of arr) {
+    if (!isAllowedByType(f, cfg.allowedExt, cfg.allowedMime)) {
+      rejects.push({ name: f.name, reason: 'INVALID_TYPE', size: f.size, type: f.type });
+      continue;
+    }
+    if (f.size > limitBytes) {
+      rejects.push({ name: f.name, reason: 'FILE_TOO_LARGE', size: f.size, type: f.type });
+      continue;
+    }
+    valids.push(f);
+  }
+
+  // 리젝트가 하나라도 있으면 에러 반환 (최대 개수 체크 전에 즉시 반려)
+  if (rejects.length > 0) {
+    // 대표 에러코드: 타입 문제 우선, 아니면 용량
+    const error: UploadError = rejects.some((r) => r.reason === 'INVALID_TYPE') ? 'INVALID_TYPE' : 'FILE_TOO_LARGE';
+    return { ok: false, error, rejects };
+  }
+
+  // 개수 제한 체크 (병합 후)
+  const merged = [...(current ?? []), ...valids];
+  if (merged.length > cfg.maxFiles) {
+    return { ok: false, error: 'TOO_MANY_FILES', rejects: [] };
+  }
+
+  return { ok: true, next: merged };
+}
+
+// (선택) input accept 속성 문자열 생성기
+export function toAcceptAttr(allowedExt?: readonly string[], allowedMime?: readonly string[]) {
+  const exts = (allowedExt ?? []).map((e) => (e.startsWith('.') ? e : `.${e}`));
+  const mimes = allowedMime ?? [];
+  return [...mimes, ...exts].join(',');
 }

--- a/src/features/update-user/ui/ImageUploader.tsx
+++ b/src/features/update-user/ui/ImageUploader.tsx
@@ -4,7 +4,8 @@ import { X, Plus } from 'lucide-react';
 import { cn } from '@/shared/lib/tailwindMerge';
 import { toast } from 'sonner';
 import Image from 'next/image';
-import { UploadConfig, validateAndMergeFiles } from '../model/userImageUpload';
+import { toAcceptAttr, UploadConfig, validateAndMergeFilesV2 } from '../model/userImageUpload';
+import { ALLOWED_EXT, ALLOWED_MIME } from '@/shared/constants/constant';
 
 type Preview = { file: File; url: string };
 
@@ -44,14 +45,29 @@ export function ImageUploader({ value, onChange, maxFiles = 3, maxSizeMB = 5, cl
   const handleFiles = (files: FileList | null) => {
     if (!files) return;
 
-    const cfg: UploadConfig = { maxFiles, maxSizeMB };
-    const res = validateAndMergeFiles(value, files, cfg);
+    const cfg: UploadConfig = { maxFiles, maxSizeMB, allowedExt: ALLOWED_EXT, allowedMime: ALLOWED_MIME };
+    const res = validateAndMergeFilesV2(value, files, cfg);
 
     if (!res.ok) {
-      if (res.error === 'TOO_MANY_FILES') {
-        toast.error(`최대 ${maxFiles}장까지만 업로드 가능합니다`);
-      } else if (res.error === 'FILE_TOO_LARGE') {
-        toast.error(`파일 크기가 ${maxSizeMB}MB 이상으로 업로드 불가합니다`);
+      switch (res.error) {
+        case 'TOO_MANY_FILES':
+          toast.error(`최대 ${maxFiles}장까지만 업로드 가능합니다`);
+          break;
+        case 'INVALID_TYPE': {
+          // 상세 사유가 있으면 최대 3개까지 노출
+          const msg =
+            res.rejects
+              ?.slice(0, 3)
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .map((r: { name: any }) => `${r.name}: 허용되지 않은 형식`)
+              .join('\n') ?? '허용되지 않은 형식의 파일이 포함되어 있어요.';
+          toast.error(`${msg}\n(허용: ${ALLOWED_EXT.join(', ')})`);
+          break;
+        }
+        case 'FILE_TOO_LARGE': {
+          toast.error(`최대 ${maxFiles}장까지만 업로드 가능합니다`);
+          break;
+        }
       }
       resetInput();
       return;
@@ -112,7 +128,7 @@ export function ImageUploader({ value, onChange, maxFiles = 3, maxSizeMB = 5, cl
       <input
         ref={inputRef}
         type="file"
-        accept="image/*"
+        accept={toAcceptAttr(ALLOWED_EXT, ALLOWED_MIME)}
         multiple
         className="hidden"
         onChange={(e) => handleFiles(e.target.files)}

--- a/src/features/update-user/ui/Step1Form.tsx
+++ b/src/features/update-user/ui/Step1Form.tsx
@@ -41,28 +41,6 @@ export const Step1Form = forwardRef<StepFormHandle, Step1FormProps>(function Ste
     shouldUnregister: false,
   });
 
-  // 다음 버튼 활성화 여부 관련
-  const setCanProceed = useOnboardingStore((s) => s.setCanProceed);
-  useEffect(() => {
-    const sub = form.watch(() => {
-      const nicknameState = form.getFieldState('nickname', form.formState);
-      const uniState = form.getFieldState('university', form.formState);
-      const genderState = form.getFieldState('gender', form.formState);
-
-      const nickname = form.getValues('nickname');
-      const verified = form.getValues('nicknameVerified');
-      const verifiedNickname = form.getValues('verifiedNickname');
-      const consent = form.getValues('privacyConsent');
-
-      const verifiedOk = verified && verifiedNickname === nickname;
-
-      const can = verifiedOk && consent && !nicknameState.invalid && !uniState.invalid && !genderState.invalid;
-
-      setCanProceed('step1', can);
-    });
-    return () => sub.unsubscribe();
-  }, [form, setCanProceed]);
-
   // 부모에 submit 핸들 노출
   useImperativeHandle(ref, () => ({
     submit: () => {
@@ -93,8 +71,15 @@ export const Step1Form = forwardRef<StepFormHandle, Step1FormProps>(function Ste
 
   const nickname = form.watch('nickname');
   const verified = form.watch('nicknameVerified');
-  const verifiedNickname = form.watch('verifiedNickname'); // ✅ 추가
+  const verifiedNickname = form.watch('verifiedNickname');
   const isVerifiedFrozen = verified && verifiedNickname === nickname;
+
+  // 다음 버튼 활성화 여부 관련
+  const setCanProceed = useOnboardingStore((s) => s.setCanProceed);
+  useEffect(() => {
+    const verifiedOk = verified && verifiedNickname === nickname;
+    setCanProceed('step1', form.formState.isValid && verifiedOk);
+  }, [form.formState.isValid, nickname, verified, verifiedNickname, setCanProceed]);
 
   const saveToStore = useOnboardingStore((s) => s.save);
   useEffect(() => {

--- a/src/features/update-user/ui/Step2Form.tsx
+++ b/src/features/update-user/ui/Step2Form.tsx
@@ -63,7 +63,7 @@ export const Step2Form = forwardRef<StepFormHandle, Step2FormProps>(function Ste
                   value={field.value || ''}
                   onConfirm={field.onChange}
                   renderOptions={(selected, setSelected) => (
-                    <div className="max-h-[250px] overflow-y-auto overscroll-contain pr-1 [-webkit-overflow-scrolling:touch]">
+                    <div className="scrollbar-hide max-h-[250px] overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch]">
                       <div className="flex h-[250px] flex-wrap content-start gap-2">
                         {items.map((opt) => {
                           const lableText = key === 'preferenceType' ? preferenceLableMapper(opt.name) : opt.name;

--- a/src/shared/constants/constant.ts
+++ b/src/shared/constants/constant.ts
@@ -11,3 +11,6 @@ export const PROGRESS_BY_STEP: Record<number, number> = {
 
 export const MESSAGE_MAX_LEN = 300;
 export const PAGE_SIZE = 20;
+
+export const ALLOWED_EXT = ['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif'] as const;
+export const ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'image/heif'] as const;


### PR DESCRIPTION
## 온보딩 유효성 검증 이슈 수정
- 순서에 상관 없이 1 스텝에 있는 모든 데이터가 맞게 들어가야지만 [다음] 버튼 활성화 되도록 기능 수정
- 이미지 파일 최소 1개 이상 업로드 필수 요건에 맞추어 에러메세지 노출 및 [완료] 버튼 활성화 기능 수정
- 이미지 파일 확장자에 대한 가드 추가 : 사용 가능 파일 확장자 - ['jpg', 'jpeg', 'png', 'webp', 'heic', 'heif']